### PR TITLE
feat: add admin panel with user and post management

### DIFF
--- a/BaseProyectoFinal/src/components/AdminPanel.jsx
+++ b/BaseProyectoFinal/src/components/AdminPanel.jsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react';
+import {
+  getUsers,
+  toggleUserStatus,
+  deleteUser,
+} from '../services/userService';
+import {
+  getPosts,
+  togglePostStatus,
+  deletePost,
+} from '../services/postService';
+
+/**
+ * Panel de administración con pestañas para gestionar usuarios y publicaciones.
+ * Las operaciones son simuladas y los cambios se reflejan en el estado local.
+ */
+export function AdminPanel() {
+  const [activeTab, setActiveTab] = useState('users');
+  const [users, setUsers] = useState([]);
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    const loadData = async () => {
+      setUsers(await getUsers());
+      setPosts(await getPosts());
+    };
+    loadData();
+  }, []);
+
+  const handleUserToggle = async (id) => {
+    const updated = await toggleUserStatus(id);
+    setUsers((prev) => prev.map((u) => (u.id === id ? updated : u)));
+    alert(`Usuario ${updated.status === 'active' ? 'activado' : 'suspendido'}`);
+    console.info(`Usuario ${id} actualizado a ${updated.status}`);
+  };
+
+  const handleUserDelete = async (id) => {
+    await deleteUser(id);
+    setUsers((prev) => prev.filter((u) => u.id !== id));
+    alert('Usuario eliminado');
+    console.info(`Usuario ${id} eliminado`);
+  };
+
+  const handlePostToggle = async (id) => {
+    const updated = await togglePostStatus(id);
+    setPosts((prev) => prev.map((p) => (p.id === id ? updated : p)));
+    alert(
+      `Publicación ${updated.status === 'active' ? 'activada' : 'suspendida'}`
+    );
+    console.info(`Publicación ${id} actualizada a ${updated.status}`);
+  };
+
+  const handlePostDelete = async (id) => {
+    await deletePost(id);
+    setPosts((prev) => prev.filter((p) => p.id !== id));
+    alert('Publicación eliminada');
+    console.info(`Publicación ${id} eliminada`);
+  };
+
+  return (
+    <div className="container mt-4">
+      <ul className="nav nav-tabs">
+        <li className="nav-item">
+          <button
+            className={`nav-link ${activeTab === 'users' ? 'active' : ''}`}
+            type="button"
+            onClick={() => setActiveTab('users')}
+          >
+            Usuarios
+          </button>
+        </li>
+        <li className="nav-item">
+          <button
+            className={`nav-link ${activeTab === 'posts' ? 'active' : ''}`}
+            type="button"
+            onClick={() => setActiveTab('posts')}
+          >
+            Publicaciones
+          </button>
+        </li>
+      </ul>
+      <div className="tab-content mt-3">
+        {activeTab === 'users' && (
+          <div className="table-responsive">
+            <table className="table table-striped align-middle">
+              <thead>
+                <tr>
+                  <th>Nombre</th>
+                  <th>Estado</th>
+                  <th>Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <tr key={user.id}>
+                    <td>{user.name}</td>
+                    <td>{user.status}</td>
+                    <td>
+                      <button
+                        className="btn btn-warning btn-sm me-2"
+                        onClick={() => handleUserToggle(user.id)}
+                      >
+                        {user.status === 'active' ? 'Suspender' : 'Activar'}
+                      </button>
+                      <button
+                        className="btn btn-danger btn-sm"
+                        onClick={() => handleUserDelete(user.id)}
+                      >
+                        Eliminar
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {activeTab === 'posts' && (
+          <div className="table-responsive">
+            <table className="table table-striped align-middle">
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Estado</th>
+                  <th>Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {posts.map((post) => (
+                  <tr key={post.id}>
+                    <td>{post.title}</td>
+                    <td>{post.status}</td>
+                    <td>
+                      <button
+                        className="btn btn-warning btn-sm me-2"
+                        onClick={() => handlePostToggle(post.id)}
+                      >
+                        {post.status === 'active' ? 'Suspender' : 'Activar'}
+                      </button>
+                      <button
+                        className="btn btn-danger btn-sm"
+                        onClick={() => handlePostDelete(post.id)}
+                      >
+                        Eliminar
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/BaseProyectoFinal/src/services/postService.js
+++ b/BaseProyectoFinal/src/services/postService.js
@@ -1,0 +1,42 @@
+/**
+ * Servicio de publicaciones para operaciones administrativas.
+ * Todas las operaciones son simuladas en memoria.
+ */
+const posts = [
+  { id: 1, title: 'Primer post', status: 'active' },
+  { id: 2, title: 'Segundo post', status: 'suspended' },
+  { id: 3, title: 'Tercer post', status: 'active' },
+];
+
+/**
+ * Obtiene todas las publicaciones disponibles.
+ * @returns {Promise<Array<{id:number,title:string,status:string}>>}
+ */
+export async function getPosts() {
+  return Promise.resolve([...posts]);
+}
+
+/**
+ * Alterna el estado de una publicación entre activo y suspendido.
+ * @param {number} id - Identificador de la publicación.
+ * @returns {Promise<{id:number,title:string,status:string}>}
+ */
+export async function togglePostStatus(id) {
+  const post = posts.find((p) => p.id === id);
+  if (!post) throw new Error('Publicación no encontrada');
+  post.status = post.status === 'active' ? 'suspended' : 'active';
+  return Promise.resolve({ ...post });
+}
+
+/**
+ * Elimina una publicación por su identificador.
+ * @param {number} id - Identificador de la publicación.
+ * @returns {Promise<void>}
+ */
+export async function deletePost(id) {
+  const index = posts.findIndex((p) => p.id === id);
+  if (index !== -1) {
+    posts.splice(index, 1);
+  }
+  return Promise.resolve();
+}

--- a/BaseProyectoFinal/src/services/userService.js
+++ b/BaseProyectoFinal/src/services/userService.js
@@ -1,0 +1,42 @@
+/**
+ * Servicio de usuarios para operaciones administrativas.
+ * Todas las operaciones son simuladas en memoria.
+ */
+const users = [
+  { id: 1, name: 'Alice', status: 'active' },
+  { id: 2, name: 'Bob', status: 'suspended' },
+  { id: 3, name: 'Charlie', status: 'active' },
+];
+
+/**
+ * Obtiene todos los usuarios registrados.
+ * @returns {Promise<Array<{id:number,name:string,status:string}>>}
+ */
+export async function getUsers() {
+  return Promise.resolve([...users]);
+}
+
+/**
+ * Alterna el estado de un usuario entre activo y suspendido.
+ * @param {number} id - Identificador del usuario.
+ * @returns {Promise<{id:number,name:string,status:string}>}
+ */
+export async function toggleUserStatus(id) {
+  const user = users.find((u) => u.id === id);
+  if (!user) throw new Error('Usuario no encontrado');
+  user.status = user.status === 'active' ? 'suspended' : 'active';
+  return Promise.resolve({ ...user });
+}
+
+/**
+ * Elimina un usuario por su identificador.
+ * @param {number} id - Identificador del usuario.
+ * @returns {Promise<void>}
+ */
+export async function deleteUser(id) {
+  const index = users.findIndex((u) => u.id === id);
+  if (index !== -1) {
+    users.splice(index, 1);
+  }
+  return Promise.resolve();
+}


### PR DESCRIPTION
## Summary
- add admin panel with Bootstrap tabs for users and posts
- simulate user and post services to toggle activation and deletion
- update local state with alerts and console info for auditing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68989ba6072c8327a09f61c9ad4ac9c5